### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,5 +15,17 @@ const deffy = require("deffy");
  * @return {Anything} The set value.
  */
 module.exports = function objDef (obj, field, defValue, opts) {
+    if (isPrototypePolluted(field))
+        throw new Error('Restricted setting magical attributes');
     return obj[field] = deffy(obj[field], defValue, opts);
 };
+
+/**
+ * isPrototypePolluted
+ * Blacklist certain keys to prevent Prototype Pollution
+ * @param {Anything} key The object key
+ * @return {Boolean}
+ */
+function isPrototypePolluted(key) {
+    return ['__proto__', 'constructor', 'prototype'].includes(key);
+}


### PR DESCRIPTION
https://huntr.dev/users/arjunshibu has fixed the Prototype Pollution vulnerability 🔨. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/obj-def/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/obj-def/1/README.md

### User Comments:

### :bar_chart: Metadata *

`obj-def` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-obj-def

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
var objDef = require("obj-def")
var obj ={}
console.log("Before : " + {}.polluted);
objDef(obj, "__proto__", {}).polluted ='Yes! Its Polluted';
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i obj-def # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

Because `prototype pollution` is exploitable by assigning a property to the function return value (the prototype object itself), fix by skipping vulnerable condition is not a good option as it will throw `Cannot set property of undefined` error like below. Instead, the fix throws a new exception when trying to assign magical attributes.

![pof](https://raw.githubusercontent.com/arjunshibu/files/main/obj-def-fix.png)


### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
